### PR TITLE
Handle potential packet splits while reading chunked footers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.rkaippully/http-kit "2.3.0-alpha4-logging3"
+(defproject org.clojars.rkaippully/http-kit "2.3.0-alpha4-logging4"
   :author "Feng Shen (@shenfeng)"
   :description "High-performance event-driven HTTP client/server for Clojure"
   :url "http://http-kit.org/"

--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -202,12 +202,15 @@ public class HttpClient implements Runnable {
                 if (req.decoder.decode(buffer) == ALL_READ) {
                     req.finish();
                     if (req.cfg.keepAlive > 0) {
-                        PersistentConn con = new PersistentConn(now + req.cfg.keepAlive, req.addr, key);
                         Map<String, String> context = req.getLogContext();
-                        if (oldState == ALL_READ)
+                        if (oldState == ALL_READ) {
                             context.put("response", req.decoder.getResponse().toString());
-                        eventLogger.log(req.logMDC, context, "Request finished reading and returns connection to keepalives.");
-                        keepalives.offer(con);
+                            eventLogger.log(req.logMDC, context, "Bug! Attempt to return connection to keepalives more than once.");
+                        } else {
+                            eventLogger.log(req.logMDC, context, "Request finished reading and returns connection to keepalives.");
+                            PersistentConn con = new PersistentConn(now + req.cfg.keepAlive, req.addr, key);
+                            keepalives.offer(con);
+                        }
                     } else {
                         closeQuietly(key);
                     }


### PR DESCRIPTION
While processing a chunked response, the footer will end with a CRLF.
It is possible that the CR and LF characters will get split into two packets
so that the ByteBuffer ends with a CR character. This causes `state` to change
to `ALL_READ` which is incorrect. It should read the LF from the next packet and
then flip state to `ALL_READ`.